### PR TITLE
ES6 classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "dependencies": {
       "jsx": "^0.1.1",
-      "react": "^0.12.2"
+      "react": "npm:react@0.13.1"
     }
   }
 }

--- a/public/js/.jshintrc
+++ b/public/js/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "esnext": true,
+  "asi": true
+}

--- a/public/js/app.jsx
+++ b/public/js/app.jsx
@@ -3,6 +3,6 @@ import React from 'react'
 import Test from './test.jsx!'
 
 React.render(
-  <Test />
-, document.getElementById('main')
+  <Test />,
+  document.getElementById('main')
 )

--- a/public/js/test.jsx
+++ b/public/js/test.jsx
@@ -1,11 +1,16 @@
 /** @jsx React.DOM */
 import React from 'react'
 
-export default React.createClass({
-    displayName: 'Test'
-  , render: function () {
-      return (
-        <div>Awesome Test!</div>
-      )
-    }
-})
+class Test extends React.Component {
+  render() {
+    return (
+      <div>Awesome Test!</div>
+    )
+  }
+}
+
+Test.defaultProps = {
+  displayName: 'Test'
+}
+
+export default Test


### PR DESCRIPTION
Refactored `test.jsx` to export an ES6 class instead of using the React class system (supported since v0.13.0).

Don't know if you're interested but figures I might as well share it. Hope you don't mind the linting.

Anyway, thanks for the work!
